### PR TITLE
F/zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,6 @@ opt := goptional.Empty[string]()
 
 // Retrieve the value held by opt or 
 // the zero value of its type otherwise.
-//
-// Some zero values:
-// string -> ""
-// bool -> false
-// int -> 0
-// ptr -> nil
 v := opt.OrZero()
 
 // Is true.
@@ -166,9 +160,9 @@ v := opt.OrElsePanicWithErr(func() error {
 opt := goptional.Of(123)
 
 // Apply a predicate to the value of opt, if there is any.
-opt = opt.Filter(func(v int) bool { return v > 100 })
+opt = opt.Filter(func(v *int) bool { return *v > 100 })
 // Returns an empty Optional, as 123 is not even.
-opt = opt.Filter(func(v int) bool { return v%2 == 0 })
+opt = opt.Filter(func(v *int) bool { return *v%2 == 0 })
 
 v := 0
 
@@ -181,8 +175,8 @@ if opt.IsPresent() {
 ```go
 // The example above can be rewritten in a fluent style.
 v := goptional.Of(123).
-    Filter(func(v int) bool { return v > 100 }).
-    Filter(func(v int) bool { return v%2 == 0 }).
+    Filter(func(v *int) bool { return *v > 100 }).
+    Filter(func(v *int) bool { return *v%2 == 0 }).
     OrElse(0)
 ```
 
@@ -195,8 +189,8 @@ opt := goptional.Of(123)
 
 // Apply the given transformation to the value of opt, if there is any,
 // and return a new Optional of the target type.
-strOpt := goptional.Map(opt, func(v int) string {
-    return fmt.Sprintf("%v_mapped", v)
+strOpt := goptional.Map(opt, func(v *int) string {
+    return fmt.Sprintf("%v_mapped", *v)
 })
 
 // v is "123_mapped"
@@ -210,8 +204,8 @@ opt := goptional.Empty[int]()
 
 // Similar to Map, but returns an Optional holding
 // the given default value if opt is empty.
-strOpt := goptional.MapOr(opt, func(v int) string {
-    return fmt.Sprintf("%v_mapped", v)
+strOpt := goptional.MapOr(opt, func(v *int) string {
+    return fmt.Sprintf("%v_mapped", *v)
 }, "default")
 
 // v is "default"
@@ -225,8 +219,8 @@ opt := goptional.Empty[int]()
 
 // Similar to Map, but returns an Optional holding
 // a default value provided by the given supplier if opt is empty.
-strOpt := goptional.MapOrElse(opt, func(v int) string {
-    return fmt.Sprintf("%v_mapped", v)
+strOpt := goptional.MapOrElse(opt, func(v *int) string {
+    return fmt.Sprintf("%v_mapped", *v)
 }, func() string {
     return "default"
 })
@@ -242,8 +236,8 @@ opt := goptional.Of(123)
 
 // FlatMap is similar to Map, but the given supplier returns an Optional instead.
 // If you are familiar with Monads, think of it as AndThen.
-strOpt := FlatMap(opt, func(v int) Optional[string] {
-    return goptional.Of(fmt.Sprintf("%v_mapped", v))
+strOpt := FlatMap(opt, func(v *int) Optional[string] {
+    return goptional.Of(fmt.Sprintf("%v_mapped", *v))
 })
 
 // v is "123_mapped"
@@ -254,7 +248,7 @@ v := strOpt.OrElse("")
 opt := goptional.Empty[int]()
 
 // Returns a new empty Optional of the target type, as opt is empty.
-strOpt := FlatMap(opt, func(v int) Optional[string] {
+strOpt := FlatMap(opt, func(v *int) Optional[string] {
     return goptional.Of(fmt.Sprintf("%v_mapped", v))
 })
 
@@ -271,7 +265,7 @@ opt := goptional.Of(123)
 
 // Execute the given action on the value of opt, if there is any.
 // Do nothing otherwise.
-opt.IfPresent(func(v int) {
+opt.IfPresent(func(v *int) {
     fmt.Println(v) // Prints '123'
 })
 ```
@@ -282,7 +276,7 @@ opt.IfPresent(func(v int) {
 opt := goptional.Empty[int]()
 
 // Similar to IfPresent, but executes a fallback action if opt is empty.
-opt.IfPresentOrElse(func(v int) {
+opt.IfPresentOrElse(func(v *int) {
     // ...
 }, func() {
     // This block will execute, as 'opt' is empty.

--- a/README.md
+++ b/README.md
@@ -419,13 +419,6 @@ if err == nil {
 1. **Why are `Map`, `MapOr`, etc. implemented as functions and not methods?**  
 As of now, Go does **not** support method-level type parameters. This might change in the future.
 
-## TODOs
-
-- [ ] `Zip`
-- [ ] `ZipWith`
-- [ ] `Unzip`
-- [ ] `UnzipWith`
-
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ import "github.com/nykolynoleg/goptional"
 ```go
 // Create an Optional of type int that holds 123.
 opt := goptional.Of(123)
+
+// If the argument to Of is either nil or invalid, an empty Optional is returned instead.
+opt2 := goptional.Of[[]string](nil)
+
+// Is true.
+if opt2.IsEmpty() {
+    // ...
+}
 ```
 
 `Empty`
@@ -53,27 +61,6 @@ if opt == nil {
 
 // Will not panic.
 if opt.IsPresent() {
-    // ...
-}
-```
-
-`OfNillable`
-
-```go
-// Create an Optional of type *string that holds the address of s.
-s := "gm goptional"
-opt := goptional.OfNillable[string](&s)
-
-// Is true.
-if opt.IsPresent() {
-    // ...
-}
-
-// If the argument to OfNillable is nil, an empty Optional is returned instead.
-opt2 := goptional.OfNillable[string](nil)
-
-// Is false.
-if opt2.IsPresent() {
     // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ opt := goptional.Empty[string]()
 // the zero value of its type otherwise.
 //
 // Some zero values:
-//  string -> ""
-//  bool -> false
-//  int -> 0
-//  ptr -> nil
+// string -> ""
+// bool -> false
+// int -> 0
+// ptr -> nil
 v := opt.OrZero()
 
 // Is true.
@@ -392,7 +392,7 @@ opt2 := opt1.Replace(789)
 opt := goptional.Of(123)
 
 // Get the JSON representation of opt.
-// []byte("null") is returned for any empty Optional.
+// Marshal returns []byte("null") if an Optional is empty.
 jsonBytes, err := opt.MarshalJSON()
 ```
 

--- a/goptional.go
+++ b/goptional.go
@@ -26,30 +26,21 @@ func Empty[T any]() Optional[T] {
 }
 
 // Of returns a new Optional that holds the given value.
-// It panics if value is nil or invalid.
+// It returns an empty Optional if the given value is either invalid or nil.
 func Of[T any](value T) (opt Optional[T]) {
 	v := reflect.ValueOf(value)
 	if !v.IsValid() {
-		panic("value is invalid")
+		return Empty[T]()
 	}
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func:
 		if v.IsNil() {
-			panic("value is nil")
+			return Empty[T]()
 		}
 		fallthrough
 	default:
 		return []T{value}
 	}
-}
-
-// OfNillable returns a new Optional that holds the given pointer.
-// If value is nil, an empty Optional is returned instead.
-func OfNillable[T any](value *T) (opt Optional[*T]) {
-	if value == nil {
-		return Empty[*T]()
-	}
-	return Of(value)
 }
 
 // IsPresent returns true if this instance holds a value, and false otherwise.
@@ -361,7 +352,7 @@ func ZipWith[X, Y, Z any](o1 Optional[X], o2 Optional[Y], mapper func(*X, *Y) Z)
 	return Empty[Z]()
 }
 
-// Flatten flattens the given optional.
+// Flatten flattens the given Optional.
 func Flatten[T any](o Optional[Optional[T]]) Optional[T] {
 	if o.IsPresent() {
 		return o.Get()

--- a/goptional.go
+++ b/goptional.go
@@ -360,3 +360,11 @@ func ZipWith[X, Y, Z any](o1 Optional[X], o2 Optional[Y], mapper func(*X, *Y) Z)
 	}
 	return Empty[Z]()
 }
+
+// Flatten flattens the given optional.
+func Flatten[T any](o Optional[Optional[T]]) Optional[T] {
+	if o.IsPresent() {
+		return o.Get()
+	}
+	return Empty[T]()
+}

--- a/goptional.go
+++ b/goptional.go
@@ -304,3 +304,45 @@ func (o *Optional[T]) Replace(value T) Optional[T] {
 	*o = inOpt
 	return Of(v)
 }
+
+// Pair is your usual generic pair.
+type Pair[X, Y any] struct {
+	// First is the first element of the pair.
+	First X
+	// Second is the second element of the pair.
+	Second Y
+}
+
+// Zip zips o1 with o2.
+// If o1 and o2 are both non-empty, it returns an optional pair holding the value of o1 & o2.
+//
+// Otherwise, an empty Optional is returned.
+func Zip[X, Y any](o1 Optional[X], o2 Optional[Y]) Optional[*Pair[X, Y]] {
+	if o1.IsPresent() && o2.IsPresent() {
+		return Of(&Pair[X, Y]{First: o1.Get(), Second: o2.Get()})
+	}
+	return Empty[*Pair[X, Y]]()
+}
+
+// Unzip unzips o containing a tuple of two Optionals.
+// If o is empty, it returns the unwrapped pair. Otherwise, two empty Optionals are returned.
+func Unzip[X, Y any](o Optional[*Pair[Optional[X], Optional[Y]]]) (Optional[X], Optional[Y]) {
+	if o.IsPresent() {
+		pair := o.Get()
+		return pair.First, pair.Second
+	}
+	return Empty[X](), Empty[Y]()
+}
+
+// ZipWith zips o1 with o2.
+// If o1 and o2 are both non-empty, it returns an Optional with a value
+// that results from the application of the given mapper to the value of o1 & o2.
+// Otherwise, an empty Optional is returned.
+//
+// It panics if o1 & o2 are both non-empty and mapper is nil.
+func ZipWith[X, Y, Z any](o1 Optional[X], o2 Optional[Y], mapper func(X, Y) Z) Optional[Z] {
+	if o1.IsPresent() && o2.IsPresent() {
+		return Of(mapper(o1.Get(), o2.Get()))
+	}
+	return Empty[Z]()
+}

--- a/goptional.go
+++ b/goptional.go
@@ -183,15 +183,15 @@ func (o Optional[T]) Or(supplier func() Optional[T]) Optional[T] {
 
 // Xor returns one of the following:
 //   - an empty Optional if both are either non-empty or empty
-//   - the first non-empty Optional between this instance & opt
-func (o Optional[T]) Xor(opt Optional[T]) Optional[T] {
-	if (o.IsPresent() && opt.IsPresent()) || (o.IsEmpty() && opt.IsEmpty()) {
+//   - the first non-empty Optional between this instance & o2
+func (o Optional[T]) Xor(o2 Optional[T]) Optional[T] {
+	if (o.IsPresent() && o2.IsPresent()) || (o.IsEmpty() && o2.IsEmpty()) {
 		return Empty[T]()
 	}
 	if o.IsPresent() {
 		return o
 	}
-	return opt
+	return o2
 }
 
 // OrZero returns the value held by this instance, if there is any, or the zero value of T otherwise.

--- a/goptional_test.go
+++ b/goptional_test.go
@@ -736,7 +736,7 @@ type sampleStruct struct {
 	Z []string `json:"z"`
 }
 
-var sampleStructInst = sampleStruct{
+var sampleStructInst = &sampleStruct{
 	X: "gmgn",
 	Y: true,
 	Z: []string{"a", "b", "c"},
@@ -804,7 +804,7 @@ func TestUnmarshalJSON_ValidDataOnEmpty(t *testing.T) {
 	err := opt.UnmarshalJSON([]byte(sampleJSON))
 	require.NoError(t, err)
 	require.True(t, opt.IsPresent())
-	require.EqualValues(t, opt.Get(), &sampleStructInst)
+	require.EqualValues(t, opt.Get(), sampleStructInst)
 }
 
 func TestUnmarshalJSON_ValidDataOnNotEmpty(t *testing.T) {
@@ -816,7 +816,7 @@ func TestUnmarshalJSON_ValidDataOnNotEmpty(t *testing.T) {
 	err := opt.UnmarshalJSON([]byte(sampleJSON))
 	require.NoError(t, err)
 	require.True(t, opt.IsPresent())
-	require.EqualValues(t, opt.Get(), sampleStructInst)
+	require.EqualValues(t, opt.Get(), *sampleStructInst)
 }
 
 func TestFlatten_Empty(t *testing.T) {

--- a/goptional_test.go
+++ b/goptional_test.go
@@ -118,19 +118,19 @@ func TestGet_NilValue(t *testing.T) {
 
 func TestIfPresent_NotEmpty(t *testing.T) {
 	optVal := 0
-	Of(123).IfPresent(func(x int) { optVal = x })
+	Of(123).IfPresent(func(x *int) { optVal = *x })
 	require.EqualValues(t, optVal, 123)
 }
 
 func TestIfPresent_Empty(t *testing.T) {
 	called := false
-	Empty[int]().IfPresent(func(_ int) { called = true })
+	Empty[int]().IfPresent(func(_ *int) { called = true })
 	require.False(t, called)
 }
 
 func TestIfPresent_NilValue(t *testing.T) {
 	called := false
-	OfNillable[[]string](nil).IfPresent(func(_ *[]string) { called = true })
+	OfNillable[[]string](nil).IfPresent(func(_ **[]string) { called = true })
 	require.False(t, called)
 }
 
@@ -150,21 +150,21 @@ func TestIfPresent_NilActionOnNotEmpty(t *testing.T) {
 
 func TestIfPresentOrElse_Empty(t *testing.T) {
 	var actionCalled, emptyActionCalled bool
-	Empty[string]().IfPresentOrElse(func(_ string) { actionCalled = true }, func() { emptyActionCalled = true })
+	Empty[string]().IfPresentOrElse(func(_ *string) { actionCalled = true }, func() { emptyActionCalled = true })
 	require.False(t, actionCalled)
 	require.True(t, emptyActionCalled)
 }
 
 func TestIfPresentOrElse_NilValue(t *testing.T) {
 	var actionCalled, emptyActionCalled bool
-	OfNillable[string](nil).IfPresentOrElse(func(_ *string) { actionCalled = true }, func() { emptyActionCalled = true })
+	OfNillable[string](nil).IfPresentOrElse(func(_ **string) { actionCalled = true }, func() { emptyActionCalled = true })
 	require.False(t, actionCalled)
 	require.True(t, emptyActionCalled)
 }
 
 func TestIfPresentOrElse_NotEmpty(t *testing.T) {
 	var actionCalled, emptyActionCalled bool
-	Of(123).IfPresentOrElse(func(_ int) { actionCalled = true }, func() { emptyActionCalled = true })
+	Of(123).IfPresentOrElse(func(_ *int) { actionCalled = true }, func() { emptyActionCalled = true })
 	require.True(t, actionCalled)
 	require.False(t, emptyActionCalled)
 }
@@ -180,31 +180,31 @@ func TestIfPresentOrElse_NilEmptyActionOnEmpty(t *testing.T) {
 	defer func() {
 		require.NotNil(t, recover())
 	}()
-	Empty[string]().IfPresentOrElse(func(_ string) {}, nil)
+	Empty[string]().IfPresentOrElse(func(_ *string) {}, nil)
 }
 
 func TestIfPresentOrElse_NilEmptyActionOnNilValue(t *testing.T) {
 	defer func() {
 		require.NotNil(t, recover())
 	}()
-	OfNillable[string](nil).IfPresentOrElse(func(_ *string) {}, nil)
+	OfNillable[string](nil).IfPresentOrElse(func(_ **string) {}, nil)
 }
 
 func TestFilter_Empty(t *testing.T) {
 	opt := Empty[string]()
-	opt = opt.Filter(func(_ string) bool { return true })
+	opt = opt.Filter(func(_ *string) bool { return true })
 	require.True(t, opt.IsEmpty())
 }
 
 func TestFilter_NilValue(t *testing.T) {
 	opt := OfNillable[[]string](nil)
-	opt = opt.Filter(func(_ *[]string) bool { return true })
+	opt = opt.Filter(func(_ **[]string) bool { return true })
 	require.True(t, opt.IsEmpty())
 }
 
 func TestFilter_NotEmpty(t *testing.T) {
 	opt := Of(123)
-	opt = opt.Filter(func(_ int) bool { return true })
+	opt = opt.Filter(func(_ *int) bool { return true })
 	require.True(t, opt.IsPresent())
 }
 
@@ -221,24 +221,24 @@ func TestFilter_NilPredicateOnNotEmpty(t *testing.T) {
 
 func TestFilter_PredicateNotOkOnEmpty(t *testing.T) {
 	opt := Empty[string]()
-	opt = opt.Filter(func(_ string) bool { return false })
+	opt = opt.Filter(func(_ *string) bool { return false })
 	require.True(t, opt.IsEmpty())
 }
 
 func TestFilter_PredicateNotOkOnNilValue(t *testing.T) {
 	opt := OfNillable[string](nil)
-	opt = opt.Filter(func(_ *string) bool { return false })
+	opt = opt.Filter(func(_ **string) bool { return false })
 	require.True(t, opt.IsEmpty())
 }
 
 func TestFilter_PredicateNotOkOnNotEmpty(t *testing.T) {
 	opt := Of(123)
-	opt = opt.Filter(func(_ int) bool { return false })
+	opt = opt.Filter(func(_ *int) bool { return false })
 	require.True(t, opt.IsEmpty())
 }
 
 func TestMap_Empty(t *testing.T) {
-	opt := Map(Empty[string](), func(s string) string { return s })
+	opt := Map(Empty[string](), func(s *string) string { return *s })
 	require.True(t, opt.IsEmpty())
 }
 
@@ -248,7 +248,7 @@ func TestMap_NilMapperOnEmpty(t *testing.T) {
 }
 
 func TestMap_NotEmpty(t *testing.T) {
-	opt := Map(Of(123), func(x int) string { return fmt.Sprintf("%v", x) })
+	opt := Map(Of(123), func(x *int) string { return fmt.Sprintf("%v", *x) })
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "123")
 }
@@ -264,7 +264,7 @@ func TestMap_NilInput(t *testing.T) {
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	Map(nil, func(i int) string { return "goptional" })
+	Map(nil, func(_ *int) string { return "goptional" })
 }
 
 func TestMap_NilMapperOnNilInput(t *testing.T) {
@@ -275,7 +275,7 @@ func TestMap_NilMapperOnNilInput(t *testing.T) {
 }
 
 func TestMapOr_Empty(t *testing.T) {
-	opt := MapOr(Empty[string](), func(s string) string { return s }, "default")
+	opt := MapOr(Empty[string](), func(s *string) string { return *s }, "default")
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "default")
 }
@@ -287,7 +287,7 @@ func TestMapOr_NilMapperOnEmpty(t *testing.T) {
 }
 
 func TestMapOr_NotEmpty(t *testing.T) {
-	opt := MapOr(Of(123), func(x int) string { return fmt.Sprintf("%v", x) }, "default")
+	opt := MapOr(Of(123), func(x *int) string { return fmt.Sprintf("%v", *x) }, "default")
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "123")
 }
@@ -303,7 +303,7 @@ func TestMapOr_NilInput(t *testing.T) {
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	MapOr(nil, func(i int) string { return "goptional" }, "default")
+	MapOr(nil, func(_ *int) string { return "goptional" }, "default")
 }
 
 func TestMapOr_NilMapperOnNilInput(t *testing.T) {
@@ -314,7 +314,7 @@ func TestMapOr_NilMapperOnNilInput(t *testing.T) {
 }
 
 func TestMapOrElse_Empty(t *testing.T) {
-	opt := MapOrElse(Empty[string](), func(s string) string { return s }, func() string { return "default" })
+	opt := MapOrElse(Empty[string](), func(s *string) string { return *s }, func() string { return "default" })
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "default")
 }
@@ -326,7 +326,7 @@ func TestMapOrElse_NilMapperOnEmpty(t *testing.T) {
 }
 
 func TestMapOrElse_NotEmpty(t *testing.T) {
-	opt := MapOrElse(Of(123), func(x int) string { return fmt.Sprintf("%v", x) }, func() string { return "default" })
+	opt := MapOrElse(Of(123), func(x *int) string { return fmt.Sprintf("%v", *x) }, func() string { return "default" })
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "123")
 }
@@ -342,7 +342,7 @@ func TestMapOrElse_NilInput(t *testing.T) {
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	MapOrElse(nil, func(i int) string { return "goptional" }, func() string { return "default" })
+	MapOrElse(nil, func(_ *int) string { return "goptional" }, func() string { return "default" })
 }
 
 func TestMapOrElse_NilMapperOnNilInput(t *testing.T) {
@@ -356,11 +356,11 @@ func TestMapOrElse_NilSupplierOnEmpty(t *testing.T) {
 	defer func() {
 		require.NotNil(t, recover())
 	}()
-	MapOrElse(Empty[string](), func(x string) int { return 0 }, nil)
+	MapOrElse(Empty[string](), func(_ *string) int { return 0 }, nil)
 }
 
 func TestFlatMap_Empty(t *testing.T) {
-	opt := FlatMap(Empty[string](), func(x string) Optional[int] { return Of(123) })
+	opt := FlatMap(Empty[string](), func(_ *string) Optional[int] { return Of(123) })
 	require.True(t, opt.IsEmpty())
 }
 
@@ -370,13 +370,13 @@ func TestFlatMap_NilMapperOnEmpty(t *testing.T) {
 }
 
 func TestFlatMap_MapToNotEmptyOnNotEmpty(t *testing.T) {
-	opt := FlatMap(Of(123), func(x int) Optional[string] { return Of(fmt.Sprintf("%v", x)) })
+	opt := FlatMap(Of(123), func(x *int) Optional[string] { return Of(fmt.Sprintf("%v", *x)) })
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), "123")
 }
 
 func TestFlatMap_MapToEmptyOnNotEmpty(t *testing.T) {
-	opt := FlatMap(Of(123), func(x int) Optional[string] { return Empty[string]() })
+	opt := FlatMap(Of(123), func(_ *int) Optional[string] { return Empty[string]() })
 	require.True(t, opt.IsEmpty())
 }
 
@@ -391,7 +391,7 @@ func TestFlatMap_NilInput(t *testing.T) {
 	defer func() {
 		require.Nil(t, recover())
 	}()
-	FlatMap(nil, func(x int) Optional[string] { return Of("123") })
+	FlatMap(nil, func(_ *int) Optional[string] { return Of("123") })
 }
 
 func TestFlatMap_NilMapperOnNilInput(t *testing.T) {

--- a/goptional_test.go
+++ b/goptional_test.go
@@ -818,3 +818,79 @@ func TestUnmarshalJSON_ValidDataOnNotEmpty(t *testing.T) {
 	require.True(t, opt.IsPresent())
 	require.EqualValues(t, opt.Get(), sampleStructInst)
 }
+
+func TestFlatten_Empty(t *testing.T) {
+	require.True(t, Flatten(Empty[Optional[int]]()).IsEmpty())
+}
+
+func TestFlatten_NotEmpty(t *testing.T) {
+	opt := Flatten(Of(Of(123)))
+	require.True(t, opt.IsPresent())
+	require.EqualValues(t, opt.Get(), 123)
+}
+
+func TestZip_Empty(t *testing.T) {
+	require.True(t, Zip(Empty[int](), Empty[string]()).IsEmpty())
+	require.True(t, Zip(Of(123), Empty[string]()).IsEmpty())
+	require.True(t, Zip(Empty[int](), Of("gm")).IsEmpty())
+}
+
+func TestZip_BothNotEmpty(t *testing.T) {
+	opt := Zip(Of(123), Of("gm"))
+	require.True(t, opt.IsPresent())
+
+	v := opt.Get()
+	require.EqualValues(t, v.First, 123)
+	require.EqualValues(t, v.Second, "gm")
+}
+
+func TestUnzip_Empty(t *testing.T) {
+	o1, o2 := Unzip(Empty[*Pair[Optional[int], Optional[string]]]())
+	require.True(t, o1.IsEmpty())
+	require.True(t, o2.IsEmpty())
+}
+
+func TestUnzip_BothNotEmpty(t *testing.T) {
+	pair := &Pair[Optional[int], Optional[string]]{First: Of(123), Second: Of("gm")}
+	o1, o2 := Unzip(Of(pair))
+
+	require.True(t, o1.IsPresent())
+	require.EqualValues(t, o1, pair.First)
+
+	require.True(t, o2.IsPresent())
+	require.EqualValues(t, o2, pair.Second)
+
+}
+
+func TestUnzip_LeftEmpty(t *testing.T) {
+	pair := &Pair[Optional[int], Optional[string]]{First: Empty[int](), Second: Of("gm")}
+	o1, o2 := Unzip(Of(pair))
+
+	require.True(t, o1.IsEmpty())
+	require.EqualValues(t, o1, pair.First)
+
+	require.True(t, o2.IsPresent())
+	require.EqualValues(t, o2, pair.Second)
+}
+
+func TestUnzip_RightEmpty(t *testing.T) {
+	pair := &Pair[Optional[int], Optional[string]]{First: Of(123), Second: Empty[string]()}
+	o1, o2 := Unzip(Of(pair))
+
+	require.True(t, o1.IsPresent())
+	require.EqualValues(t, o1, pair.First)
+
+	require.True(t, o2.IsEmpty())
+	require.EqualValues(t, o2, pair.Second)
+}
+
+func TestUnzip_BothEmpty(t *testing.T) {
+	pair := &Pair[Optional[int], Optional[string]]{First: Empty[int](), Second: Empty[string]()}
+	o1, o2 := Unzip(Of(pair))
+
+	require.True(t, o1.IsEmpty())
+	require.EqualValues(t, o1, pair.First)
+
+	require.True(t, o2.IsEmpty())
+	require.EqualValues(t, o2, pair.Second)
+}


### PR DESCRIPTION
Added the following capabilities:
- `Flatten`
- `Zip`
- `ZipWith`
- `Unzip`

Removed `OfNillable`.

Now `Of` fallbacks to an empty `Optional` if its argument is either invalid or `nil`. Effectively, `OfNillable`'s behaviour is now incorporated into `Of`.
Managing the nils provided by mappers with `OfNillable` would make the API far too verbose and difficult to understand.

Callbacks that make use of an Optional's value now accept it by pointer.

Updated tests & usage accordingly.